### PR TITLE
Add net merchandising value series to 2025 demo ecommerce dashboard

### DIFF
--- a/demo ecommerce/dashboards/demo_dashboard_2025.page.aml
+++ b/demo ecommerce/dashboards/demo_dashboard_2025.page.aml
@@ -787,6 +787,15 @@ To ensure consistent interpretation of financial metrics, here’s how value flo
             }
           }
         }
+        series {
+          field: VizFieldFull {
+            ref: r(demo_ecommerce_version_2.nmv)
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
       }
       settings {
         row_limit: 5000


### PR DESCRIPTION
## Overview
Added a new data series for net merchandising value (`nmv`) to the `demo_dashboard_2025` ecommerce dashboard. This enhancement provides users with direct visibility of a key financial metric, improving the dashboard's value for revenue and profitability analysis.

## Changes
- Added `nmv` field series visualization to the `demo_dashboard_2025.page.aml` dashboard
- Enabled consistent number formatting for the new `nmv` metric
- ... minor adjustments to visualization configuration

This update improves business monitoring of net merchandising value trends alongside existing financial metrics, supporting better decision-making.

## Holistics

Review this PR in Holistics at: https://testing4.holistics.io/studio/projects/30434/explore?branch=khai-to-dev

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)