### PR TITLE
Adjust block position in khai_test dashboard for improved layout

### DIFF
--- a/team-folders/khai/khai_test.page.aml
+++ b/team-folders/khai/khai_test.page.aml
@@ -27,7 +27,7 @@ Dashboard khai_test {
         layer: 5
       }
       block v_6g2o {
-        position: pos(340, 700, 580, 120)
+        position: pos(360, 700, 580, 120)
         layer: 6
       }
     }


### PR DESCRIPTION
## Overview
Minor layout adjustment in the `khai_test` dashboard to improve visual alignment of a dashboard block. This change enhances the user experience by refining the dashboard presentation without affecting any data or metrics.

## Changes
- Moved block `v_6g2o` position slightly from `pos(340, 700, 580, 120)` to `pos(360, 700, 580, 120)` to improve alignment


## Holistics

Review this PR in Holistics at: https://testing4.holistics.io/studio/projects/30434/explore?branch=khai-to-dev

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)